### PR TITLE
feat(nodenv): gets node version from service

### DIFF
--- a/app/templates/base/_node-version
+++ b/app/templates/base/_node-version
@@ -1,1 +1,1 @@
-4.1
+<%= version_alias %>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^0.16.5",
     "shelljs": "^0.4.0",
     "yeoman-generator": "^0.18.9",
-    "yosay": "^1.0.2"
+    "yosay": "^1.0.2",
+    "semver": "^5.0.3"
   }
 }


### PR DESCRIPTION
The idea is to have a endpoint to get the latest node version that we
are using at platanus. The endpoint is http://node.platan.us/latest

The generator gets the version of the service and generates the
corresponding `.node-version`

If the service is down, if fallback to whatever node version the
generator it's being run on. This is done via the process.version
variable.